### PR TITLE
Fixes for search results page

### DIFF
--- a/mdn-dark.user.css
+++ b/mdn-dark.user.css
@@ -233,8 +233,16 @@
   .search-pane {
     background-color: var(--gray-2);
   }
-  .search-results-container mark {
+  .search-results-list .title a:link,
+  .search-results-list .title a:visited {
     color: var(--gray-9);
+  }
+  .search-results-list mark {
+    background-color: var(--red-1);
+  }
+  .search-results .highlight,
+  .search-results .summary {
+      color: var(--gray-9);
   }
   .article .prev-next a.button, .article .prevnext a.button {
     color: var(--gray-e);


### PR DESCRIPTION
Hi,

first of all, thank you very much for the user style!

I've noticed that search result pages (like [this one](https://developer.mozilla.org/en-US/search?q=picture)) were pretty much unreadable:

![image](https://user-images.githubusercontent.com/4048809/119227432-59bd4300-bafd-11eb-81da-ad84c70756ec.png)

This PR fixes that:

![image](https://user-images.githubusercontent.com/4048809/119227440-6b9ee600-bafd-11eb-9731-c9ea3b3e1893.png)

I have used `--red-1` for the highlights as that was the only appropriate option among the existing colors, but I am definitely open if you prefer something else here.