### PR TITLE
Mozilla seems to have places link inside the h2 and h3 headers to help

### DIFF
--- a/mdn-dark.user.css
+++ b/mdn-dark.user.css
@@ -34,7 +34,7 @@
   main {
     background: var(--gray-1);
   }
-  h1, h2, h3, h4, h5, h6, header {
+  h1, h2, h3, h4, h5, h6, header, .main-page-content h2 a:link, .main-page-content h2 a:visited, .main-page-content h3 a:link, .main-page-content h3 a:visited {
     color: var(--gray-9);
   }
   a:link, a:visited {


### PR DESCRIPTION
with easier references. They enforce the link color to a quite dark
color making it quite difficult to see over the already dark background.

This small patch addresses the issue by apply the same grey colors to
links present in h2 and h3 headers.

Before
![image](https://user-images.githubusercontent.com/1161681/133912702-387131c5-2252-4f63-8088-63e7e6c88229.png)

After
![image](https://user-images.githubusercontent.com/1161681/133912716-ffb6d5e5-4396-42b8-85b6-6ce183d2c6c3.png)
