### PR TITLE
Mozilla has added a breadcrumb at the top of the page and set a class

### DIFF
--- a/mdn-dark.user.css
+++ b/mdn-dark.user.css
@@ -131,7 +131,7 @@
   #main-header .nav-main-item > a, .login > a, .toolbox > ul > li > a {
     color: var(--blue-1);
   }
-  .main-menu, .page-header {
+  .main-menu, .page-header, .breadcrumb-locale-container {
     background-color: var(--gray-2);
   }
   ul.main-menu, .page-header-main {


### PR DESCRIPTION
named `breadcrumb-locale-container` to define its background color to a
very light color.

This patch addresses the breadcrumb background color and reverts it to
the `page-header` class as defined in this user-style.

Before
![image](https://user-images.githubusercontent.com/1161681/133912830-732393e7-8e3a-4c59-aa8a-ea721f39fbaf.png)

After
![image](https://user-images.githubusercontent.com/1161681/133912847-eb07e038-e405-4fd0-ba70-80ea7c6da206.png)
