### PR TITLE
Mozilla defines a `notecard` class that enforces colors on their inner

### DIFF
--- a/mdn-dark.user.css
+++ b/mdn-dark.user.css
@@ -314,7 +314,6 @@
     background-color: var(--gray-2);
     color: var(--gray-9);
   }
-  }
   .indicator-info, .optional, .template-jsOverrides {
     background-color: var(--gray-2);
   }

--- a/mdn-dark.user.css
+++ b/mdn-dark.user.css
@@ -37,7 +37,7 @@
   h1, h2, h3, h4, h5, h6, header {
     color: var(--gray-9);
   }
-  a:link, a:visited {
+  a:link, a:visited, .notecard a:link, .notecard a:visited {
     color: var(--blue-3);
   }
   .article h2 a:link, .article h2 a:visited, .article h2 code {
@@ -313,6 +313,7 @@
   .notecard.deprecated {
     background-color: var(--gray-2);
     color: var(--gray-9);
+  }
   }
   .indicator-info, .optional, .template-jsOverrides {
     background-color: var(--gray-2);


### PR DESCRIPTION
links. The color chosen is almost black and this makes any inner links
almost impossible to read.

This patch addresses the color issue and reapplies the same colors used
for other links.

Before
![image](https://user-images.githubusercontent.com/1161681/133913066-cca06288-cecb-4bec-b017-68fca72f8ee5.png)

After
![image](https://user-images.githubusercontent.com/1161681/133913072-3ba9fa4c-61b7-4aeb-9958-ae416ab00dd8.png)
